### PR TITLE
Omd

### DIFF
--- a/omd/README.rst
+++ b/omd/README.rst
@@ -10,11 +10,11 @@ If your site requires OMD to run with tmpfs, remove the line in start.sh that di
 
 Build from Dockerfile::
 
-	docker build -rm -t omd . 
+	docker build -rm -t omd .
 
 Create data-only volume. OMD site configurations will be auto-generated in /opt/omd/sites. ::
 
-    docker run -v /opt/omd/sites -v /config --name omd_config scratch true &> /dev/null
+    docker run -v /opt/omd/sites -v /config --name omd_config busybox
 
 Edit the msmtprc and msmtp-aliases files with your email SMTP info. Default site/user is omd. Then::
 

--- a/omd/start.sh
+++ b/omd/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SITE=omd
+SITE=default
 
 # Link msmtp data volume to /etc/msmtprc
 chgrp omd /config/msmtp*
@@ -22,4 +22,4 @@ else
 	omd mv temp "$SITE"
 fi
 omd start "$SITE"
-tail -f /opt/omd/sites/monitoring/var/log/nagios.log
+tail -f "/opt/omd/sites/$SITE/var/log/nagios.log"


### PR DESCRIPTION
Fix `start.sh` script so that creates the site with a name of `default` instead of `omd` which causes the script to choke.

Also update `README` with updated docker run command for volume container.